### PR TITLE
Fix dwi b0 name

### DIFF
--- a/config_spine.txt
+++ b/config_spine.txt
@@ -81,7 +81,7 @@
         },    
         {
             "dataType": "dwi",
-            "modalityLabel": "b0",
+            "modalityLabel": "acq-b0_dwi",
             "criteria": {
                 "SeriesDescription": "DWI_b0",
                 "ProtocolName": "DWI_b0"


### PR DESCRIPTION
In accordance with [BIDS specs](https://github.com/bids-standard/bids-specification/blob/2c81be7c745721ecd14a8bafdd53b360da378424/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#diffusion-imaging-data)